### PR TITLE
ATARI's new `redirectUri`

### DIFF
--- a/roles/xaas-auth/vars/satosa-vars.yml
+++ b/roles/xaas-auth/vars/satosa-vars.yml
@@ -42,3 +42,8 @@ oidc_clients:
     - https://matrix-fsd.epfl.ch/
     response_types:
     - code
+  - client_id: ATARI
+    redirect_uris:
+    - https://itsidevfsd0024.xaas.epfl.ch/
+    response_types:
+    - code

--- a/roles/xaas-auth/vars/satosa-vars.yml
+++ b/roles/xaas-auth/vars/satosa-vars.yml
@@ -44,6 +44,6 @@ oidc_clients:
     - code
   - client_id: ATARI
     redirect_uris:
-    - https://itsidevfsd0024.xaas.epfl.ch/
+    - https://atari-test.epfl.ch/
     response_types:
     - code


### PR DESCRIPTION
`https://itsidevfsd0024.xaas.epfl.ch/` -> `https://atari-test.epfl.ch/`